### PR TITLE
Correct docker image urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ docker run -d \
   -e POSTGRES_PASSWORD=localrecall \
   -p 5432:5432 \
   -v postgres_data:/var/lib/postgresql/data \
-  quay.io/mudler/localrecall:latest-postgresql
+  quay.io/mudler/localrecall:main-postgresql
 ```
 
 2. **Start LocalRecall** with PostgreSQL:
@@ -169,7 +169,7 @@ docker run -ti \
   -e HYBRID_SEARCH_BM25_WEIGHT=0.5 \
   -e HYBRID_SEARCH_VECTOR_WEIGHT=0.5 \
   -p 8080:8080 \
-  quay.io/mudler/localrecall
+  quay.io/mudler/localrecall:latest
 ```
 
 #### PostgreSQL Features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     command:
       - granite-embedding-107m-multilingual
   postgres:
-    #image: quay.io/mudler/localrecall:v0.5.2-postgresql
+    #image: quay.io/mudler/localrecall:main-postgresql
     build:
       context: .
       dockerfile: Dockerfile.pgsql
@@ -31,7 +31,7 @@ services:
       timeout: 5s
       retries: 5
   ragserver:
-    #image: quay.io/mudler/localrecall:v0.5.2
+    #image: quay.io/mudler/localrecall:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This pull request updates the Docker image tags in both the `README.md` and `docker-compose.yml` files to use the latest and main branches instead of specific versions. This ensures that users and developers are working with the most up-to-date images and simplifies maintenance.

**Docker image tag updates:**

* Updated the PostgreSQL Docker image tag in the `README.md` example from `latest-postgresql` to `main-postgresql` to reflect the current main branch.
* Changed the LocalRecall Docker image tag in the `README.md` example from an untagged image to `latest` for clarity and consistency.
* Modified the commented-out PostgreSQL image tag in `docker-compose.yml` from `v0.5.2-postgresql` to `main-postgresql` to align with the main branch.
* Updated the commented-out LocalRecall image tag in `docker-compose.yml` from `v0.5.2` to `latest` to use the latest available image.